### PR TITLE
Update to Github link instead of Gitlab

### DIFF
--- a/pages/licensing.md
+++ b/pages/licensing.md
@@ -9,7 +9,7 @@ permalink: /licensing/
 For information about licensing on our wiki sites, see [this page](https://meta.weirdgloop.org/w/Project:Copyrights) on our meta wiki.
 
 ### Source code
-The source code for some of our sites, extensions, and tools, are publicly accessible on [GitLab](https://gitlab.com/weirdgloop). For the majority of our repositories, the code is licensed under [GNU General Public License v2](https://choosealicense.com/licenses/gpl-2.0/) or later, however some projects may have a different license or no license at all. Please check for a `COPYING` or `LICENSE` file, or information in the `README` file, for information. If license information cannot be found in any of those, the project doesn't have a license and will be subject to our copyright.
+The source code for some of our sites, extensions, and tools, are publicly accessible on [GitHub](https://github.com/weirdgloop). For the majority of our repositories, the code is licensed under [GNU General Public License v2](https://choosealicense.com/licenses/gpl-2.0/) or later, however some projects may have a different license or no license at all. Please check for a `COPYING` or `LICENSE` file, or information in the `README` file, for information. If license information cannot be found in any of those, the project doesn't have a license and will be subject to our copyright.
 
 ### Maps
 We host a map server at <code>maps.runescape.wiki</code> for displaying interactive maps on the RuneScape and Old School RuneScape wikis. The map's underlying code is subject to our licensing, under the [GNU General Public License v3](https://choosealicense.com/licenses/gpl-3.0/), and utilises [Leaflet](https://github.com/Leaflet/Leaflet).


### PR DESCRIPTION
This updates the link from gitlab to GitHub where the repositories are hosted :) 